### PR TITLE
Revert "Update module name for OT fork"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/opentable/grafana-api-golang-client
+module github.com/grafana/grafana-api-golang-client
 
 go 1.14
 


### PR DESCRIPTION
Reverts opentable/grafana-api-golang-client#1

We can use a `replace` directive in a project's go.mod instead of renaming the module on this fork.